### PR TITLE
fix: point plugin at git.bkl.sh after bkl repo move

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # asdf-bkl [![Build](https://github.com/fredsmith/asdf-bkl/actions/workflows/build.yml/badge.svg)](https://github.com/fredsmith/asdf-bkl/actions/workflows/build.yml) [![Lint](https://github.com/fredsmith/asdf-bkl/actions/workflows/lint.yml/badge.svg)](https://github.com/fredsmith/asdf-bkl/actions/workflows/lint.yml)
 
-[bkl](https://bkl.gopatchy.io/) plugin for the [asdf version manager](https://asdf-vm.com).
+[bkl](https://bkl.sh/) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -10,20 +10,15 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
 curl_opts=(-sI)
 
-if [ -n "${GITHUB_API_TOKEN:-}" ]; then
-	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
-fi
-
-# curl of REPO/releases/latest is expected to be a 302 to another URL
-# when no releases redirect_url="REPO/releases"
-# when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
-redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
+# curl of REPO/releases/latest redirects to REPO/releases/tag/v<VERSION> when a
+# release exists. The location header may be absolute or repo-relative.
+redirect_url=$(curl "${curl_opts[@]}" "$BKL_REPO/releases/latest" | sed -n -e "s|^location: *||p" | tr -d '\r')
 version=
 printf "redirect url: %s\n" "$redirect_url" >&2
-if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
-else
+if [[ "$redirect_url" == */tag/* ]]; then
 	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+else
+	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
 fi
 
 printf "%s\n" "$version"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/gopatchy/bkl"
+BKL_REPO="https://git.bkl.sh/bkl/bkl"
 TOOL_NAME="bkl"
 TOOL_TEST="bkl --version"
 
@@ -13,23 +13,19 @@ fail() {
 
 curl_opts=(-fsSL)
 
-if [ -n "${GITHUB_API_TOKEN:-}" ]; then
-	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
-fi
-
 sort_versions() {
 	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
 		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-list_github_tags() {
-	git ls-remote --tags --refs "$GH_REPO" |
+list_repo_tags() {
+	git ls-remote --tags --refs "$BKL_REPO" |
 		grep -o 'refs/tags/.*' | cut -d/ -f3- |
 		sed 's/^v//'
 }
 
 list_all_versions() {
-	list_github_tags
+	list_repo_tags
 }
 
 get_arch() {
@@ -67,7 +63,7 @@ download_release() {
 	version="$1"
 	filename="$2"
 
-	url="${GH_REPO}/releases/download/v${version}/bkl-${platform}-${arch}-v${version}.tar.gz"
+	url="${BKL_REPO}/releases/download/v${version}/bkl-${platform}-${arch}-v${version}.tar.gz"
 	echo "* Downloading $TOOL_NAME release $version..."
 	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
 }


### PR DESCRIPTION
## Description

bkl moved from `github.com/gopatchy/bkl` to `git.bkl.sh/bkl/bkl`. This points the plugin at the new host.

The new host runs Gitea, so both of the ways `GH_REPO` was load-bearing survive the move: tag listing is plain `git ls-remote`, and release assets are served at the same `/releases/download/<tag>/<file>` path with the same `bkl-<platform>-<arch>-v<version>.tar.gz` filenames. No separate URL template or `go install` fallback needed.

Two things did not carry over:

- **`GITHUB_API_TOKEN` header removed.** It was only ever meaningful against GitHub. Renaming it along with the repo constant would have sent a GitHub credential to an unrelated third-party host on every list/download. It bought nothing here anyway — the tag listing is plain git and Gitea's asset downloads are public.
- **`latest-stable` redirect handling.** Gitea returns a repo-relative `Location` (`/bkl/bkl/releases/tag/v1.0.55`) where GitHub returned an absolute URL. The old no-releases check compared the header against `"$GH_REPO/releases"`, which can never match a relative path. It now keys off the presence of `/tag/` and falls back to the sorted tag list otherwise, which works with either header style.

`GH_REPO` → `BKL_REPO` and `list_github_tags` → `list_repo_tags`, since neither is GitHub-specific any more. README's bkl link updated to `bkl.sh`.

## Motivation and Context

Correction to an earlier claim in this PR description: the old `github.com/gopatchy/bkl` repo is **not** dead — it still serves tags and release assets — so the plugin is not broken today. It is frozen at v1.0.54. The new host is where releases continue: v1.0.55 ("Move to bkl.sh") exists only on `git.bkl.sh`. Without this change the plugin silently caps out at 1.0.54 and never sees new versions.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

Verified end to end on darwin/arm64:

- `bin/list-all` — lists tags through 1.0.55
- `bin/latest-stable` — returns `1.0.55`
- `bin/download` + `bin/install` of 1.0.55 — installed binary reports `path git.bkl.sh/bkl/bkl/cmd/bkl`, a real release build

`shellcheck` and `shfmt --diff` both clean.

linux/amd64 is not covered locally; the `plugin_test` matrix on ubuntu-latest covers it in CI.

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

